### PR TITLE
Update 02-create-app.md

### DIFF
--- a/tutorial/02-create-app.md
+++ b/tutorial/02-create-app.md
@@ -23,7 +23,6 @@ Before moving on, add some additional dependencies that you will use later.
 - [Microsoft.Extensions.Configuration](https://github.com/aspnet/Extensions) to read application configuration from a JSON file.
 - [Microsoft Authentication Library (MSAL) for .NET](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet) to authenticate the user and acquire access tokens.
 - [Microsoft Graph .NET Client Library](https://github.com/microsoftgraph/msgraph-sdk-dotnet) to make calls to the Microsoft Graph.
-- [Authentication Providers for Microsoft Graph .NET SDK](https://github.com/microsoftgraph/msgraph-sdk-dotnet-auth) to enable the Graph client library to request tokens automatically when making API calls.
 
 Run the following commands in your CLI to install the dependencies.
 


### PR DESCRIPTION
Removed auth providers package from bulleted list of dependencies. The tutorial never actually used this package, so it was misleading.

Thanks to @markolbert for pointing this out.

Fixes #6