### PR TITLE
Refactored app configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -330,4 +330,3 @@ ASALocalRun/
 .mfractor/
 
 .vscode/
-appsettings.json

--- a/demos/01-create-app/GraphTutorial/GraphTutorial.csproj
+++ b/demos/01-create-app/GraphTutorial/GraphTutorial.csproj
@@ -6,10 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.0" />
     <PackageReference Include="Microsoft.Graph" Version="1.21.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.7.1" />
   </ItemGroup>

--- a/demos/02-add-aad-auth/GraphTutorial/GraphTutorial.csproj
+++ b/demos/02-add-aad-auth/GraphTutorial/GraphTutorial.csproj
@@ -3,13 +3,11 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.2</TargetFramework>
+    <UserSecretsId>18e2660e-92a2-41fc-a160-eea5942d89da</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.0" />
     <PackageReference Include="Microsoft.Graph" Version="1.21.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.7.1" />
   </ItemGroup>

--- a/demos/02-add-aad-auth/GraphTutorial/Program.cs
+++ b/demos/02-add-aad-auth/GraphTutorial/Program.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 using Microsoft.Extensions.Configuration;
 using System;
-using System.IO;
 
 namespace GraphTutorial
 {
@@ -21,7 +20,8 @@ namespace GraphTutorial
             }
 
             var appId = appConfig["appId"];
-            var scopes = appConfig.GetSection("scopes").Get<string[]>();
+            var scopesString = appConfig["scopes"];
+            var scopes = scopesString.Split(';');
 
             // Initialize the auth provider with values from appsettings.json
             var authProvider = new DeviceCodeAuthProvider(appId, scopes);
@@ -70,14 +70,12 @@ namespace GraphTutorial
         static IConfigurationRoot LoadAppSettings()
         {
             var appConfig = new ConfigurationBuilder()
-                .SetBasePath(Directory.GetCurrentDirectory())
-                .AddJsonFile("appsettings.json", false, true)
+                .AddUserSecrets<Program>()
                 .Build();
 
             // Check for required settings
             if (string.IsNullOrEmpty(appConfig["appId"]) ||
-                // Make sure there's at least one value in the scopes array
-                string.IsNullOrEmpty(appConfig["scopes:0"]))
+                string.IsNullOrEmpty(appConfig["scopes"]))
             {
                 return null;
             }

--- a/demos/02-add-aad-auth/GraphTutorial/appsettings.json.example
+++ b/demos/02-add-aad-auth/GraphTutorial/appsettings.json.example
@@ -1,7 +1,0 @@
-{
-  "appId": "YOUR_APP_ID_HERE",
-  "scopes": [
-    "User.Read",
-    "Calendars.Read"
-  ]
-}

--- a/demos/03-add-msgraph/GraphTutorial/GraphTutorial.csproj
+++ b/demos/03-add-msgraph/GraphTutorial/GraphTutorial.csproj
@@ -1,17 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.2</TargetFramework>
+    <UserSecretsId>18e2660e-92a2-41fc-a160-eea5942d89da</UserSecretsId>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.0" />
     <PackageReference Include="Microsoft.Graph" Version="1.21.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.7.1" />
   </ItemGroup>
-
 </Project>

--- a/demos/03-add-msgraph/GraphTutorial/Program.cs
+++ b/demos/03-add-msgraph/GraphTutorial/Program.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 using Microsoft.Extensions.Configuration;
 using System;
-using System.IO;
 
 namespace GraphTutorial
 {
@@ -21,7 +20,8 @@ namespace GraphTutorial
             }
 
             var appId = appConfig["appId"];
-            var scopes = appConfig.GetSection("scopes").Get<string[]>();
+            var scopesString = appConfig["scopes"];
+            var scopes = scopesString.Split(';');
 
             // Initialize the auth provider with values from appsettings.json
             var authProvider = new DeviceCodeAuthProvider(appId, scopes);
@@ -107,14 +107,12 @@ namespace GraphTutorial
         static IConfigurationRoot LoadAppSettings()
         {
             var appConfig = new ConfigurationBuilder()
-                .SetBasePath(Directory.GetCurrentDirectory())
-                .AddJsonFile("appsettings.json", false, true)
+                .AddUserSecrets<Program>()
                 .Build();
 
             // Check for required settings
             if (string.IsNullOrEmpty(appConfig["appId"]) ||
-                // Make sure there's at least one value in the scopes array
-                string.IsNullOrEmpty(appConfig["scopes:0"]))
+                string.IsNullOrEmpty(appConfig["scopes"]))
             {
                 return null;
             }

--- a/demos/03-add-msgraph/GraphTutorial/appsettings.json.example
+++ b/demos/03-add-msgraph/GraphTutorial/appsettings.json.example
@@ -1,7 +1,0 @@
-{
-  "appId": "YOUR_APP_ID_HERE",
-  "scopes": [
-    "User.Read",
-    "Calendars.Read"
-  ]
-}

--- a/tutorial/02-create-app.md
+++ b/tutorial/02-create-app.md
@@ -20,17 +20,14 @@ Begin by creating a new .NET Core console project using the [.NET Core CLI](/dot
 
 Before moving on, add some additional dependencies that you will use later.
 
-- [Microsoft.Extensions.Configuration](https://github.com/aspnet/Extensions) to read application configuration from a JSON file.
+- [Microsoft.Extensions.Configuration.UserSecrets](https://github.com/aspnet/extensions) to read application configuration from the [.NET development secret store](https://docs.microsoft.com/aspnet/core/security/app-secrets).
 - [Microsoft Authentication Library (MSAL) for .NET](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet) to authenticate the user and acquire access tokens.
 - [Microsoft Graph .NET Client Library](https://github.com/microsoftgraph/msgraph-sdk-dotnet) to make calls to the Microsoft Graph.
 
 Run the following commands in your CLI to install the dependencies.
 
 ```Shell
-dotnet add package Microsoft.Extensions.Configuration --version 3.1.0
-dotnet add package Microsoft.Extensions.Configuration.FileExtensions --version 3.1.0
-dotnet add package Microsoft.Extensions.Configuration.Json --version 3.1.0
-dotnet add package Microsoft.Extensions.Configuration.Binder --version 3.1.0
+dotnet add package Microsoft.Extensions.Configuration.UserSecrets --version 3.1.0
 dotnet add package Microsoft.Identity.Client --version 4.7.1
 dotnet add package Microsoft.Graph --version 1.21.0
 ```


### PR DESCRIPTION
Instead of using appsettings.json, app now uses the .NET development user secret store (https://docs.microsoft.com/aspnet/core/security/app-secrets).

This removes the issue from https://github.com/MicrosoftDocs/feedback/issues/2347, since appsettings.json no longer exists.

Thanks @markolbert for raising this.

Fixes #7 